### PR TITLE
Implement building types with unit queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ This project is a straightforward demonstration of a tile-based RTS game develop
 - **Unit Selection:** Drag with the left mouse button to select units.
 - **Unit Movement:** Right-click to command selected units to move to the desired location.
 - **Spawn Units:** Click the "Spawn Unit" button on the control panel to add a new unit, which will deduct some gold from your resources.
+- **Construct Buildings:** Use the "Build" button to place Barracks, Resource Depots, or Towers on open grass tiles. Right-click a Barracks to queue new units.
 
 This project serves as a basic foundation for more advanced RTS mechanics and gameplay features.

--- a/src/BuildingManager.java
+++ b/src/BuildingManager.java
@@ -2,6 +2,12 @@ import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 
+enum BuildingType {
+    BARRACKS,
+    DEPOT,
+    TOWER
+}
+
 /**
  * BuildingManager handles construction and rendering of buildings.
  */
@@ -37,6 +43,25 @@ public class BuildingManager {
     public List<Building> getBuildings() {
         return buildings;
     }
+
+    /**
+     * Returns the building at the given point, or null if none exists.
+     */
+    public Building getBuildingAt(Point p) {
+        for(Building b : buildings) {
+            if(b.contains(p)) return b;
+        }
+        return null;
+    }
+
+    /**
+     * Updates all buildings and spawns units if training is complete.
+     */
+    public void updateBuildings(List<Unit> units) {
+        for(Building b : buildings) {
+            b.update(units);
+        }
+    }
 }
 
 /**
@@ -44,7 +69,10 @@ public class BuildingManager {
  */
 class Building {
     private int x, y, width, height;
-    private String type;
+    private BuildingType type;
+    private int queue = 0;
+    private int buildTimer = 0;
+    private static final int TRAIN_TIME = 120;
 
     /**
      * Constructs a building.
@@ -54,7 +82,7 @@ class Building {
      * @param height The height of the building.
      * @param type The type or name of the building.
      */
-    public Building(int x, int y, int width, int height, String type) {
+    public Building(int x, int y, int width, int height, BuildingType type) {
         this.x = x;
         this.y = y;
         this.width = width;
@@ -72,7 +100,7 @@ class Building {
         g.setColor(Color.BLACK);
         g.drawRect(x, y, width, height);
         g.setColor(Color.WHITE);
-        g.drawString(type, x + 5, y + 15);
+        g.drawString(type.toString(), x + 5, y + 15);
     }
 
     /**
@@ -82,6 +110,25 @@ class Building {
      */
     public boolean contains(Point p) {
         return new Rectangle(x, y, width, height).contains(p);
+    }
+
+    public BuildingType getType() { return type; }
+
+    public void queueUnit() {
+        if(type == BuildingType.BARRACKS) {
+            queue++;
+        }
+    }
+
+    public void update(List<Unit> units) {
+        if(type == BuildingType.BARRACKS && queue > 0) {
+            buildTimer++;
+            if(buildTimer >= TRAIN_TIME) {
+                buildTimer = 0;
+                queue--;
+                units.add(new Unit(x + width/2, y + height/2));
+            }
+        }
     }
 
     // Optional getters for building properties


### PR DESCRIPTION
## Summary
- add `BuildingType` enum and tracking for build queues
- allow buildings to spawn queued units
- select building type before placement in `GamePanel`
- right-click barracks to queue units
- document new building controls in README

## Testing
- `javac src/*.java`

------
https://chatgpt.com/codex/tasks/task_e_683f7ff237b0832eb169266928192f1c