### PR TITLE
Improve map generation with natural terrain and bridges

### DIFF
--- a/src/Pathfinder.java
+++ b/src/Pathfinder.java
@@ -51,7 +51,8 @@ public class Pathfinder {
                 int nx = current.x + d[0];
                 int ny = current.y + d[1];
                 if (nx < 0 || ny < 0 || nx >= map.getWidth() || ny >= map.getHeight()) continue;
-                if (map.getTile(nx, ny) != Tile.GRASS) continue;
+                Tile t = map.getTile(nx, ny);
+                if (t != Tile.GRASS && t != Tile.BRIDGE) continue;
                 if (closed[ny][nx]) continue;
                 int gNew = current.g + 1;
                 int hNew = manhattan(new Point(nx, ny), goal);


### PR DESCRIPTION
## Summary
- improve GameMap generation with seashores, lakes, rivers and bridges
- render bridge tiles in both main view and mini map
- make pathfinding treat bridge tiles as passable

## Testing
- `javac src/*.java`
- `java -cp src MainMenu` *(fails: no X11 DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_683f8296df3c832ea4ef6f51ca838f82