### PR TITLE
Fix build placement cancel and editor sizing

### DIFF
--- a/src/MapEditor.java
+++ b/src/MapEditor.java
@@ -27,6 +27,8 @@ public class MapEditor extends JFrame {
 
         panel = new EditorPanel();
         add(panel);
+        // ensure the frame fits the editing panel so the entire map is visible
+        pack();
     }
 
     private class EditorPanel extends JPanel implements MouseListener {

--- a/src/RTSGame.java
+++ b/src/RTSGame.java
@@ -407,6 +407,11 @@ class GamePanel extends JPanel implements MouseListener, MouseMotionListener, Ac
 
             buildMode = false;
             return;
+        } else if(buildMode && SwingUtilities.isRightMouseButton(e)) {
+            // allow the user to cancel building placement with right click
+            buildMode = false;
+            repaint();
+            return;
         }
         if(SwingUtilities.isLeftMouseButton(e)) {
             isSelecting = true;


### PR DESCRIPTION
## Summary
- add right-click cancel for build mode so users aren't stuck
- pack the map editor window so the entire map fits in view

## Testing
- `javac src/*.java`
- `java -cp src MainMenu` *(fails: No X11 DISPLAY variable)*

------
https://chatgpt.com/codex/tasks/task_e_683f8aa765f0832e968d08ea5c02081d