### PR TITLE
Add profile page example

### DIFF
--- a/src/main/java/rts/MainMenu.java
+++ b/src/main/java/rts/MainMenu.java
@@ -26,12 +26,14 @@ public class MainMenu extends JFrame {
 
         JButton startButton = new JButton("Start Game");
         JButton editorButton = new JButton("Map Editor");
+        JButton profileButton = new JButton("Profile");
         JButton settingsButton = new JButton("Settings");
         JButton exitButton = new JButton("Exit");
 
         Font btnFont = startButton.getFont().deriveFont(Font.PLAIN, 16f);
         startButton.setFont(btnFont);
         editorButton.setFont(btnFont);
+        profileButton.setFont(btnFont);
         settingsButton.setFont(btnFont);
         exitButton.setFont(btnFont);
 
@@ -50,12 +52,16 @@ public class MainMenu extends JFrame {
         gbc.gridy = 2;
         add(editorButton, gbc);
 
-        // Add Settings button
+        // Add Profile button
         gbc.gridy = 3;
+        add(profileButton, gbc);
+
+        // Add Settings button
+        gbc.gridy = 4;
         add(settingsButton, gbc);
 
         // Add Exit button
-        gbc.gridy = 4;
+        gbc.gridy = 5;
         add(exitButton, gbc);
 
         // Action listener for "Start Game"
@@ -72,6 +78,14 @@ public class MainMenu extends JFrame {
             SwingUtilities.invokeLater(() -> {
                 MapEditor editor = new MapEditor();
                 editor.setVisible(true);
+            });
+        });
+
+        // Action listener for "Profile"
+        profileButton.addActionListener(e -> {
+            SwingUtilities.invokeLater(() -> {
+                ProfilePage profile = new ProfilePage();
+                profile.setVisible(true);
             });
         });
 

--- a/src/main/java/rts/ProfilePage.java
+++ b/src/main/java/rts/ProfilePage.java
@@ -1,0 +1,62 @@
+package rts;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Simple test profile page showcasing UI components like progress bar and statistics.
+ */
+public class ProfilePage extends JFrame {
+    private JProgressBar expBar;
+    private JLabel nameLabel, gamesLabel, winsLabel, lossesLabel;
+
+    public ProfilePage() {
+        setTitle("Player Profile");
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+        setSize(350, 250);
+        setLocationRelativeTo(null);
+        setLayout(new GridBagLayout());
+        getContentPane().setBackground(new Color(60, 60, 60));
+
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(10, 10, 10, 10);
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.gridwidth = 2;
+
+        nameLabel = new JLabel("Player: TestUser");
+        nameLabel.setFont(nameLabel.getFont().deriveFont(Font.BOLD, 18f));
+        nameLabel.setForeground(Color.WHITE);
+        add(nameLabel, gbc);
+
+        gbc.gridy++;
+        expBar = new JProgressBar(0, 100);
+        expBar.setValue(70);
+        expBar.setStringPainted(true);
+        add(expBar, gbc);
+
+        gbc.gridwidth = 1;
+        gbc.gridy++;
+        gamesLabel = new JLabel("Games Played: 12");
+        gamesLabel.setForeground(Color.WHITE);
+        add(gamesLabel, gbc);
+
+        gbc.gridx = 1;
+        winsLabel = new JLabel("Wins: 8");
+        winsLabel.setForeground(Color.WHITE);
+        add(winsLabel, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        lossesLabel = new JLabel("Losses: 4");
+        lossesLabel.setForeground(Color.WHITE);
+        add(lossesLabel, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        gbc.gridwidth = 2;
+        JButton closeButton = new JButton("Close");
+        add(closeButton, gbc);
+        closeButton.addActionListener(e -> dispose());
+    }
+}


### PR DESCRIPTION
## Summary
- create `ProfilePage` UI for demonstration
- add Profile button to main menu
- wire navigation to show the profile page

## Testing
- `javac @sources.txt` (compile all sources)

------
https://chatgpt.com/codex/tasks/task_e_6840c0e93040832ebe4f0ddb147791e1